### PR TITLE
fix: configure Firebase hosting to serve from dist directory

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
     "indexes": "firestore.indexes.json"
   },
   "hosting": {
-    "public": "public",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
- Change public directory from '/' to 'dist' for proper build output
- Ensure Firebase hosting serves the built React application files
- Align with Vite's default build output directory